### PR TITLE
Add API Requests and API DB Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .vscode/  # VSCode settings
 build/
 dist/
+main_db.json

--- a/backend/api_requests.py
+++ b/backend/api_requests.py
@@ -1,0 +1,33 @@
+import requests, json # Import Requests for HTTP and JSON for data handling
+from pathlib import Path # Import Path for file path handling
+def request_api(): # Function to request data from the ElectionGuide API
+    domain = "https://electionguide.org/" # Domain of the API provider
+    path = "api/v2/elections_demo/?format=json" # Path to the specific API endpoint
+
+    token = "f37e79e510d0506ab9a8d8b82d37ae8a4f5c9b9b" # Secret API token for authentication
+
+    url = domain + path # Combination of domain and path for request
+
+    myHeaders = {'Authorization': 'Token ' + token} # Header to store information regarding the request sent
+
+    response = requests.get(url, headers=myHeaders) # Send a HTTP request to the URL with the header defined
+
+    print(f"Status Code: {response.status_code}") # Print the Status code to show outcome
+
+    jsonData = response.json() # Cast the dictionary into JSON format
+
+    file_path = Path(__file__).resolve().parent.parent / 'resources' / 'api_data' / 'main_db.json'  # File path to DB
+
+    with open(file_path, 'w') as file: # open file from filepath in write mode
+        json.dump(jsonData, file) # Dump the JSON data fetched into the file
+
+def read_api_data():
+    file_path = Path(__file__).resolve().parent.parent / 'resources' / 'api_data' / 'main_db.json' # File path to DB
+    
+    with open(file_path, 'r') as file: # Open file at filepath in read mode
+        data = json.load(file) # Load the JSON data into variable
+
+    return data # Return the JSON data
+
+if __name__ == "__main__":
+    print(read_api_data())

--- a/backend/api_requests.py
+++ b/backend/api_requests.py
@@ -4,7 +4,7 @@ def request_api(): # Function to request data from the ElectionGuide API
     domain = "https://electionguide.org/" # Domain of the API provider
     path = "api/v2/elections_demo/?format=json" # Path to the specific API endpoint
 
-    token = "f37e79e510d0506ab9a8d8b82d37ae8a4f5c9b9b" # Secret API token for authentication
+    token = "CANNOT BE SHARED" # Secret API token for authentication
 
     url = domain + path # Combination of domain and path for request
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
 blinker==1.9.0
+certifi==2025.4.26
+charset-normalizer==3.4.2
 click==8.2.0
 Flask==3.1.0
+idna==3.10
 itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
+requests==2.32.3
+urllib3==2.4.0
 Werkzeug==3.1.3


### PR DESCRIPTION
This Pull request adds api_requests.py
This file can be used as a module and can be used to request new API DBs.
The way it works is when request_api() is triggered the ElectionGuide API is asked for the DB and this is then dumped locally into the JSON.
Then read_api_data() can be used to read the cached data.

request_api() deliberately does not return a value to encourage myself to use the cached version of the DB instead to prevent too many requests being sent to the ElectionGuide API

Closes #10 
Closes #8 