### PR TITLE
Fix Mouse Cursor Appearance over certian elements

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -60,6 +60,7 @@ header {
     color: black;
     text-shadow: 2px 1px 4px rgba(0,0,0,0.6);
     transition: ease 0.1s;
+    cursor: pointer;
 }
 
 #ribbon h3:hover {
@@ -95,6 +96,7 @@ header {
     height: 90%;
     max-width: fit-content;
     transition: ease 0.1s;
+    cursor: pointer;
 }
 
 .tool:hover {
@@ -144,6 +146,7 @@ main {
     border-radius: 1rem;
     color: white;
     font-weight: 200;
+    cursor: default;
 }
 
 #continent-section {
@@ -169,6 +172,7 @@ main {
     padding-right: 0.5rem;
     transition: ease 0.1s;
     border-radius: 0.5rem;
+    cursor: pointer;
 }
 
 .continent-option:hover {
@@ -215,6 +219,7 @@ main {
     padding-right: 0.5rem;
     transition: ease 0.1s;
     border-radius: 0.5rem;
+    cursor: pointer;
 }
 
 .country-option:hover {
@@ -253,6 +258,7 @@ main {
     padding-right: 0.5rem;
     transition: ease 0.1s;
     border-radius: 0.5rem;
+    cursor: pointer;
 }
 
 .election-option:hover {


### PR DESCRIPTION
Closes #24 

The cursor will now be treated as a pointer over the ribbon options, tools, countries, continents and election options. Additionally the headers in each section of the Load Election Workspace have had the default cursor style applied too.