### PR TITLE
Refine the Datapoint names on the Select Data Workspace

### DIFF
--- a/backend/datapoint_refinement.py
+++ b/backend/datapoint_refinement.py
@@ -36,7 +36,7 @@ def getDatapointsList(election):
     counter = 0
     for datapoint in datapointsStruct:
         if type(datapoint) == dict:
-            if list(datapoint.keys())[0] == 'parties' or list(datapoint.keys())[0] == 'voting_methods' or list(datapoint.keys())[0] == 'candidates':
+            if list(datapoint.keys())[0] == 'parties' or list(datapoint.keys())[0] == 'voting_methods' or list(datapoint.keys())[0] == 'candidates' or list(datapoint.keys())[0] == 'third_party_verification' or list(datapoint.keys())[0] == 'legal_environment':
                 simplifiedDatapointsStruct.append(list(datapoint.keys())[0])
             else:
                 simplifiedDatapointsStruct.append(datapoint)

--- a/static/js/datapoints.js
+++ b/static/js/datapoints.js
@@ -17,8 +17,23 @@ function fetchDatapoints(electionId) {
             document.getElementById('select-data-election-name').innerHTML = simpleDatapointsList.shift(); // Remove the first element which is the election name
 
             for (const datapoint of simpleDatapointsList) {
+                
+                let friendlyDatapoint = "";
+                let capitalise = true
+                for (let i=0; i<datapoint.length; i++) {
+                    if (datapoint[i] === "_") {
+                        friendlyDatapoint += " "
+                        capitalise = true
+                    } else if (capitalise === true) {
+                        friendlyDatapoint += datapoint[i].toUpperCase()
+                        capitalise = false
+                    } else {
+                        friendlyDatapoint += datapoint[i]
+                    }
+                }
+
                 document.getElementById("unselected-datapoints-scroller").innerHTML += `
-                <p onclick="toggleSelection(this)">${datapoint}</p>
+                <p onclick="toggleSelection(this)" data-datapoint-key="${datapoint}">${friendlyDatapoint}</p>
                 `
             }
          }) // Return the datapoints


### PR DESCRIPTION
Instead of appearing exactly as they do on the database, the datapoints will appear on the screen in a manner that is more UI friendly.

ie:
'election_key' -> 'Election Key'
'date_updated' -> 'Date Updated'
